### PR TITLE
Expand README with usage and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# svgeditor
+# SVG Editor
+
+A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disappear based on start and end times, allowing you to create time-based annotations.
+
+## Features
+- Draw rectangles, circles, lines, arrows, polygons, and text.
+- Specify the start and end times for each element.
+- Preview visibility with a timeline slider.
+- Save drawings to a JSON file and load them back later.
+
+## Getting Started
+1. Clone or download this repository.
+2. Open `index.html` in any modern web browser.
+
+No build step or server is required; everything runs locally.
+
+## Usage
+1. Choose a tool from the **Tool** dropdown.
+2. Set the desired start and end times.
+3. Draw on the canvas.
+4. Drag the timeline slider to preview element visibility.
+5. Use **Save** to download the current drawing as `drawing.json`.
+6. Use the file input next to **Save** to load a previously saved drawing.
+
+## License
+This project is available under the MIT License.


### PR DESCRIPTION
## Summary
- Flesh out README with project description, features, usage steps, and license information.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d682eba48331a5bf60ae8f8b9054