### PR TITLE
Allow editing of timing and text for selected elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disa
 ## Features
 - Draw rectangles, circles, lines, arrows, polygons, and text.
 - Specify the start and end times for each element.
+- Edit start/end times and text of selected elements.
 - Preview visibility with a timeline slider.
 - Save drawings to a JSON file and load them back later.
 - Move elements by selecting them or by holding Ctrl and clicking to temporarily enter selection mode.
@@ -17,7 +18,7 @@ No build step or server is required; everything runs locally.
 
 ## Usage
 1. Choose a tool from the **Tool** dropdown.
-2. Set the desired start and end times.
+2. Set the desired start and end times. Selecting an element fills these fields (and the text field for text elements) so you can adjust its properties.
 3. Draw on the canvas.
    - Hold <kbd>Ctrl</kbd> and click an existing element to select and drag it without changing tools.
 4. Drag the timeline slider to preview element visibility.

--- a/script.js
+++ b/script.js
@@ -221,6 +221,11 @@ function selectElement(el) {
   if (selectedElement) selectedElement.classList.remove('selected');
   selectedElement = el;
   selectedElement.classList.add('selected');
+  startInput.value = el.dataset.start || 0;
+  endInput.value = el.dataset.end || 0;
+  if (el.tagName === 'text') {
+    textInput.value = el.textContent;
+  }
 }
 
 function deselect() {
@@ -335,6 +340,26 @@ document.addEventListener('keydown', e => {
 });
 
 timeSlider.addEventListener('input', updateVisibility);
+
+startInput.addEventListener('input', () => {
+  if (selectedElement) {
+    selectedElement.dataset.start = startInput.value;
+    updateVisibility();
+  }
+});
+
+endInput.addEventListener('input', () => {
+  if (selectedElement) {
+    selectedElement.dataset.end = endInput.value;
+    updateVisibility();
+  }
+});
+
+textInput.addEventListener('input', () => {
+  if (selectedElement && selectedElement.tagName === 'text') {
+    selectedElement.textContent = textInput.value;
+  }
+});
 
 function updateVisibility() {
   const t = Number(timeSlider.value);


### PR DESCRIPTION
## Summary
- Populate toolbar fields with selected element's timing and text so they can be modified
- Document how selected elements can have start/end and text adjusted

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baba4e2c1c8331abd1abe2558e3829