### PR TITLE
feat: edit stroke and fill colors of selected elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disa
 ## Features
 - Draw rectangles, circles, lines, arrows, polygons, and text.
 - Specify the start and end times for each element.
-- Edit start/end times and text of selected elements.
+- Edit start/end times, text, stroke, and fill colors of selected elements.
 - Preview visibility with a timeline slider.
 - Save drawings to a JSON file and load them back later.
 - Move elements by selecting them or by holding Ctrl and clicking to temporarily enter selection mode.

--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
     <label>開始: <input type="number" id="startTime" value="0" /></label>
     <label>終了: <input type="number" id="endTime" value="10" /></label>
     <label>テキスト: <input type="text" id="textInput" /></label>
+    <label>線色: <input type="color" id="strokeColor" value="#000000" /></label>
+    <label>塗り色: <input type="color" id="fillColor" value="#ffffff" /></label>
     <button id="saveBtn">Save</button>
     <button id="deleteBtn">削除</button>
     <input type="file" id="loadInput" />

--- a/script.js
+++ b/script.js
@@ -7,6 +7,8 @@ const saveBtn = document.getElementById('saveBtn');
 const loadInput = document.getElementById('loadInput');
 const timeSlider = document.getElementById('timeSlider');
 const deleteBtn = document.getElementById('deleteBtn');
+const strokeInput = document.getElementById('strokeColor');
+const fillInput = document.getElementById('fillColor');
 
 let currentTool = toolSelect.value;
 let drawing = false;
@@ -220,12 +222,13 @@ function ensureArrowDef() {
 function selectElement(el) {
   if (selectedElement) selectedElement.classList.remove('selected');
   selectedElement = el;
-  selectedElement.classList.add('selected');
   startInput.value = el.dataset.start || 0;
   endInput.value = el.dataset.end || 0;
   if (el.tagName === 'text') {
     textInput.value = el.textContent;
   }
+  updateColorInputs(el);
+  selectedElement.classList.add('selected');
 }
 
 function deselect() {
@@ -258,6 +261,19 @@ function getElementStart(el) {
     default:
       return {};
   }
+}
+
+function updateColorInputs(el) {
+  const stroke = getComputedStyle(el).stroke;
+  strokeInput.value = stroke === 'none' ? '#000000' : rgbToHex(stroke);
+  const fill = getComputedStyle(el).fill;
+  fillInput.value = fill === 'none' ? '#ffffff' : rgbToHex(fill);
+}
+
+function rgbToHex(rgb) {
+  const m = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+  if (!m) return '#000000';
+  return '#' + m.slice(1).map(x => parseInt(x).toString(16).padStart(2, '0')).join('');
 }
 
 function moveElement(el, start, dx, dy) {
@@ -358,6 +374,18 @@ endInput.addEventListener('input', () => {
 textInput.addEventListener('input', () => {
   if (selectedElement && selectedElement.tagName === 'text') {
     selectedElement.textContent = textInput.value;
+  }
+});
+
+strokeInput.addEventListener('input', () => {
+  if (selectedElement) {
+    selectedElement.setAttribute('stroke', strokeInput.value);
+  }
+});
+
+fillInput.addEventListener('input', () => {
+  if (selectedElement) {
+    selectedElement.setAttribute('fill', fillInput.value);
   }
 });
 

--- a/style.css
+++ b/style.css
@@ -1,5 +1,4 @@
 body { font-family: sans-serif; }
 #toolbar { margin-bottom: 8px; }
 #canvas { border: 1px solid #ccc; }
-.selected { stroke: red; }
-text.selected { fill: red; }
+.selected { outline: 1px dashed red; }


### PR DESCRIPTION
## Summary
- allow editing stroke and fill colors for selected SVG objects
- expose color pickers in toolbar and wire them to selected element attributes
- avoid selection highlight overriding element colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68babd76523c83318a62e156c8fe5d43