### PR TITLE
Add buttons to change z-order of selected elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
     <label>塗り色: <input type="color" id="fillColor" value="#ffffff" /></label>
     <button id="saveBtn">Save</button>
     <button id="deleteBtn">削除</button>
+    <button id="bringForwardBtn">前面へ</button>
+    <button id="sendBackwardBtn">背面へ</button>
     <input type="file" id="loadInput" />
     <input type="range" id="timeSlider" min="0" max="10" value="0" />
   </div>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,8 @@ const saveBtn = document.getElementById('saveBtn');
 const loadInput = document.getElementById('loadInput');
 const timeSlider = document.getElementById('timeSlider');
 const deleteBtn = document.getElementById('deleteBtn');
+const bringForwardBtn = document.getElementById('bringForwardBtn');
+const sendBackwardBtn = document.getElementById('sendBackwardBtn');
 const strokeInput = document.getElementById('strokeColor');
 const fillInput = document.getElementById('fillColor');
 
@@ -315,6 +317,19 @@ function moveElement(el, start, dx, dy) {
   }
 }
 
+function bringToFront(el) {
+  svg.appendChild(el);
+}
+
+function sendToBack(el) {
+  const defs = svg.querySelector('defs');
+  if (defs) {
+    svg.insertBefore(el, defs.nextSibling);
+  } else {
+    svg.insertBefore(el, svg.firstChild);
+  }
+}
+
 saveBtn.addEventListener('click', () => {
   const data = Array.from(svg.children).map(el => ({
     type: el.tagName,
@@ -357,6 +372,18 @@ deleteBtn.addEventListener('click', () => {
   if (selectedElement) {
     svg.removeChild(selectedElement);
     selectedElement = null;
+  }
+});
+
+bringForwardBtn.addEventListener('click', () => {
+  if (selectedElement) {
+    bringToFront(selectedElement);
+  }
+});
+
+sendBackwardBtn.addEventListener('click', () => {
+  if (selectedElement) {
+    sendToBack(selectedElement);
   }
 });
 


### PR DESCRIPTION
## Summary
- add toolbar buttons to move selection forward or backward
- implement DOM helpers to change element stacking order while respecting defs
- wire buttons to manipulate currently selected element

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bad499995c8331a5011a3fc49f313f