### PR TITLE
Shrink time input fields for 5-digit values

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disa
 ## Features
 - Draw rectangles, circles, lines, arrows, polygons, and text.
 - Specify the start and end times for each element.
+- Start and end time fields accept values up to five digits, keeping inputs compact.
 - Edit start/end times, text, stroke, and fill colors of selected elements.
 - Preview visibility with a timeline slider.
 - Save drawings to a JSON file and load them back later.

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
         <option value="arrow">矢印</option>
       </select>
     </label>
-    <label>開始: <input type="number" id="startTime" value="0" /></label>
-    <label>終了: <input type="number" id="endTime" value="10" /></label>
+    <label>開始: <input type="number" id="startTime" value="0" max="99999" /></label>
+    <label>終了: <input type="number" id="endTime" value="10" max="99999" /></label>
     <label>テキスト: <input type="text" id="textInput" /></label>
     <label>線色: <input type="color" id="strokeColor" value="#000000" /></label>
     <label>塗り色: <input type="color" id="fillColor" value="#ffffff" /></label>

--- a/style.css
+++ b/style.css
@@ -2,3 +2,7 @@ body { font-family: sans-serif; }
 #toolbar { margin-bottom: 8px; }
 #canvas { border: 1px solid #ccc; }
 .selected { outline: 1px dashed red; }
+#startTime,
+#endTime {
+  width: 6ch;
+}


### PR DESCRIPTION
## Summary
- limit start and end time inputs to five digits with a max of 99999
- narrow time input fields to 6-character width for tighter layout
- document the compact input constraint in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bad6b3761c8331a4b5b0dee3b4c37a