### PR TITLE
Resize canvas with browser window

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <input type="file" id="loadInput" style="display:none;">
     <input type="range" id="timeSlider" min="0" max="10" value="0" />
   </div>
-  <svg id="canvas" width="800" height="600"></svg>
+  <svg id="canvas"></svg>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,17 @@ const bringForwardBtn = document.getElementById('bringForwardBtn');
 const sendBackwardBtn = document.getElementById('sendBackwardBtn');
 const strokeInput = document.getElementById('strokeColor');
 const fillInput = document.getElementById('fillColor');
+const toolbar = document.getElementById('toolbar');
+
+function resizeCanvas() {
+  const width = window.innerWidth;
+  const height = window.innerHeight - toolbar.offsetHeight;
+  svg.setAttribute('width', width);
+  svg.setAttribute('height', height);
+}
+
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
 
 let currentTool = toolSelect.value;
 let drawing = false;

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-body { font-family: sans-serif; }
+body { font-family: sans-serif; margin: 0; }
 #toolbar { margin-bottom: 8px; }
 #canvas { border: 1px solid #ccc; }
 .selected { outline: 1px dashed red; }


### PR DESCRIPTION
## Summary
- Dynamically size SVG canvas to fit current browser window
- Remove default body margin for edge-to-edge canvas

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bae4906e348331abb90e37e2f451d4