### PR TITLE
Enable rectangle resizing via bottom-right handle

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@ body { font-family: sans-serif; margin: 0; }
 #toolbar { margin-bottom: 8px; }
 #canvas { border: 1px solid #ccc; }
 .selected { outline: 1px dashed red; }
+.resize-handle { fill: #ffffff; stroke: #000000; cursor: se-resize; }
 #startTime,
 #endTime {
   width: 6ch;


### PR DESCRIPTION
## Summary
- Add resize handle to rectangles so users can drag the lower-right corner to change size
- Keep handle out of save data and reposition it when moving or scaling rectangles

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc3d2f954483319a73c80fd8f6c5f1