### PR TITLE
Enable editing polygon vertices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disa
 - Specify the start and end times for each element.
 - Start and end time fields accept values up to five digits, keeping inputs compact.
 - Edit start/end times, text, stroke, and fill colors of selected elements.
+- Adjust polygon vertices by dragging, add points with Shift+click, and remove them by double-clicking a vertex.
 - Zoom the canvas with the mouse wheel, or resize a selected element by holding Shift while scrolling.
 - Preview visibility with a timeline slider.
 - Save drawings to a JSON file and load them back later.
@@ -23,6 +24,7 @@ No build step or server is required; everything runs locally.
 2. Set the desired start and end times. Selecting an element fills these fields (and the text field for text elements) so you can adjust its properties.
 3. Draw on the canvas.
    - Hold <kbd>Ctrl</kbd> and click an existing element to select and drag it without changing tools.
+   - When editing a polygon, drag the displayed points to reposition them, Shift+click the polygon to add a point, and double-click a point to remove it.
 4. Drag the timeline slider to preview element visibility.
 5. Use **Save** to download the current drawing as `drawing.json`.
 6. Use the file input next to **Save** to load a previously saved drawing.

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@ body { font-family: sans-serif; margin: 0; }
 #canvas { border: 1px solid #ccc; }
 .selected { outline: 1px dashed red; }
 .resize-handle { fill: #ffffff; stroke: #000000; cursor: se-resize; }
+.vertex-handle { fill: #ffffff; stroke: #000000; cursor: move; }
 #startTime,
 #endTime {
   width: 6ch;


### PR DESCRIPTION
## Summary
- Allow dragging polygon vertices via on-canvas handles
- Support adding vertices with Shift+click and removing with double-click
- Document polygon vertex editing and style vertex handles

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc418c07088331b7bb2ee487c5282c