### PR TITLE
Add stroke width control for lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <label>終了: <input type="number" id="endTime" value="10" max="99999" /></label>
     <label>テキスト: <input type="text" id="textInput" /></label>
     <label>線色: <input type="color" id="strokeColor" value="#000000" /></label>
+    <label>線幅: <input type="number" id="strokeWidth" value="1" min="1" /></label>
     <label>塗り色: <input type="color" id="fillColor" value="#ffffff" /></label>
     <button id="bringForwardBtn">前面へ</button>
     <button id="sendBackwardBtn">背面へ</button>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ const bringForwardBtn = document.getElementById('bringForwardBtn');
 const sendBackwardBtn = document.getElementById('sendBackwardBtn');
 const strokeInput = document.getElementById('strokeColor');
 const fillInput = document.getElementById('fillColor');
+const strokeWidthInput = document.getElementById('strokeWidth');
 const toolbar = document.getElementById('toolbar');
 
 function resizeCanvas() {
@@ -285,6 +286,7 @@ function addRect(p1, p2) {
   rect.setAttribute('height', h);
   rect.setAttribute('fill', fillInput.value);
   rect.setAttribute('stroke', strokeInput.value);
+  rect.setAttribute('stroke-width', strokeWidthInput.value);
   setTime(rect);
   canvasContent.appendChild(rect);
   selectElement(rect);
@@ -298,6 +300,7 @@ function addCircle(p1, p2) {
   circ.setAttribute('r', r);
   circ.setAttribute('fill', fillInput.value);
   circ.setAttribute('stroke', strokeInput.value);
+  circ.setAttribute('stroke-width', strokeWidthInput.value);
   setTime(circ);
   canvasContent.appendChild(circ);
   selectElement(circ);
@@ -310,6 +313,7 @@ function addLine(p1, p2, isArrow) {
   line.setAttribute('x2', p2.x);
   line.setAttribute('y2', p2.y);
   line.setAttribute('stroke', strokeInput.value);
+  line.setAttribute('stroke-width', strokeWidthInput.value);
   if (isArrow) {
     line.setAttribute('marker-end', 'url(#arrow)');
     ensureArrowDef();
@@ -326,6 +330,7 @@ function finalizePolygon() {
   poly.setAttribute('points', polygonPoints.map(p => `${p.x},${p.y}`).join(' '));
   poly.setAttribute('fill', fillInput.value);
   poly.setAttribute('stroke', strokeInput.value);
+  poly.setAttribute('stroke-width', strokeWidthInput.value);
   setTime(poly);
   canvasContent.appendChild(poly);
   selectElement(poly);
@@ -340,6 +345,7 @@ function addText(p) {
   t.setAttribute('font-size', '16');
   t.setAttribute('fill', fillInput.value);
   t.setAttribute('stroke', strokeInput.value);
+  t.setAttribute('stroke-width', strokeWidthInput.value);
   setTime(t);
   canvasContent.appendChild(t);
   selectElement(t);
@@ -553,6 +559,8 @@ function updateColorInputs(el) {
   strokeInput.value = stroke === 'none' ? '#000000' : rgbToHex(stroke);
   const fill = getComputedStyle(el).fill;
   fillInput.value = fill === 'none' ? '#ffffff' : rgbToHex(fill);
+  const width = getComputedStyle(el).strokeWidth;
+  strokeWidthInput.value = parseFloat(width) || 1;
 }
 
 function rgbToHex(rgb) {
@@ -765,6 +773,12 @@ strokeInput.addEventListener('input', () => {
 fillInput.addEventListener('input', () => {
   if (selectedElement) {
     selectedElement.setAttribute('fill', fillInput.value);
+  }
+});
+
+strokeWidthInput.addEventListener('input', () => {
+  if (selectedElement) {
+    selectedElement.setAttribute('stroke-width', strokeWidthInput.value);
   }
 });
 


### PR DESCRIPTION
## Summary
- add toolbar input for stroke width
- allow adjusting selected element's stroke width
- apply chosen width when drawing new shapes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4763d17c8331a6713a840197300d