### PR TITLE
Add editable polyline drawing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
         <option value="circle">丸</option>
         <option value="line">ライン</option>
         <option value="polygon">ポリゴン</option>
+        <option value="polyline">ポリライン</option>
         <option value="text">文字</option>
         <option value="arrow">矢印</option>
       </select>


### PR DESCRIPTION
## Summary
- support drawing and finalizing polylines in the editor
- allow polygons and polylines to add, move, and remove vertices via handles
- add polyline option to toolbar

## Testing
- `node --check script.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4c03925c8331840714246e550ad4