### PR TITLE
Add editable path drawing tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
         <option value="line">ライン</option>
         <option value="polygon">ポリゴン</option>
         <option value="polyline">ポリライン</option>
+        <option value="path">パス</option>
         <option value="text">文字</option>
         <option value="arrow">矢印</option>
       </select>


### PR DESCRIPTION
## Summary
- support creation and editing of SVG `path` elements
- allow adding, removing, and moving path points like polylines

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a9487bc83319ccfdbd9973cacda