### PR TITLE
Add curved path drawing to SVG editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disappear based on start and end times, allowing you to create time-based annotations.
 
 ## Features
-- Draw rectangles, circles, lines, arrows, polygons, and text.
+- Draw rectangles, circles, lines, arrows, polygons, curved paths, and text.
 - Specify the start and end times for each element.
 - Start and end time fields accept values up to five digits, keeping inputs compact.
 - Edit start/end times, text, stroke, and fill colors of selected elements.


### PR DESCRIPTION
## Summary
- Implement Catmull-Rom based smoothing so Path tool draws cubic Bézier curves
- Parse and update path endpoints to preserve curves during editing
- Document curved path capability in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5e95f0dc8331a0a997e36b4bdb69