### PR TITLE
Ensure resize handle appears on first selection

### DIFF
--- a/script.js
+++ b/script.js
@@ -491,6 +491,7 @@ function addResizeHandle(rect) {
   handle.setAttribute('height', 8);
   handle.classList.add('resize-handle');
   canvasContent.appendChild(handle);
+  resizeHandle = handle;
   positionResizeHandle(rect);
   handle.addEventListener('mousedown', e => {
     e.stopPropagation();
@@ -503,7 +504,6 @@ function addResizeHandle(rect) {
       height: parseFloat(rect.getAttribute('height'))
     };
   });
-  resizeHandle = handle;
 }
 
 function removeResizeHandle() {


### PR DESCRIPTION
## Summary
- Fix resize handle setup so newly created handle is positioned after assignment

## Testing
- `npm test` *(fails: enoent Could not read package.json)*
- `npx -y -p jsdom node - <<'NODE' ...` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*


------
https://chatgpt.com/codex/tasks/task_e_68bc619868448331a3203e3c1ace2857