### PR TITLE
Add bubble tool option to toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         <option value="polyline">ポリライン</option>
         <option value="path">パス</option>
         <option value="text">文字</option>
+        <option value="bubble">吹き出し</option>
         <option value="arrow">矢印</option>
       </select>
     </label>

--- a/script.js
+++ b/script.js
@@ -71,6 +71,10 @@ toolSelect.addEventListener('change', () => {
   removeResizeHandle();
   removeVertexHandles();
   dragging = false;
+  // Bubble tool also relies on the text field; clear it only when switching away
+  if (currentTool !== 'text' && currentTool !== 'bubble') {
+    textInput.value = '';
+  }
 });
 
 svg.addEventListener('wheel', e => {


### PR DESCRIPTION
## Summary
- add speech bubble option to the tool dropdown
- reset text input only when switching away from text/bubble tools

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc654fbe7883318de3d3bf734a46fe