### PR TITLE
Use range-based visibility filter for objects

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,8 @@
     <button id="saveBtn" class="custom-button">Save</button>
     <label for="loadInput" class="custom-button">Load</label>
     <input type="file" id="loadInput" style="display:none;">
-    <input type="range" id="timeSlider" min="0" max="10" value="0" />
+    <label>表示開始: <input type="number" id="displayStart" value="0" max="99999" /></label>
+    <label>表示終了: <input type="number" id="displayEnd" value="10" max="99999" /></label>
   </div>
   <svg id="canvas">
     <g id="canvasContent"></g>

--- a/script.js
+++ b/script.js
@@ -6,7 +6,8 @@ const endInput = document.getElementById('endTime');
 const textInput = document.getElementById('textInput');
 const saveBtn = document.getElementById('saveBtn');
 const loadInput = document.getElementById('loadInput');
-const timeSlider = document.getElementById('timeSlider');
+const displayStartInput = document.getElementById('displayStart');
+const displayEndInput = document.getElementById('displayEnd');
 const deleteBtn = document.getElementById('deleteBtn');
 const bringForwardBtn = document.getElementById('bringForwardBtn');
 const sendBackwardBtn = document.getElementById('sendBackwardBtn');
@@ -1014,7 +1015,8 @@ document.addEventListener('keydown', e => {
   }
 });
 
-timeSlider.addEventListener('input', updateVisibility);
+displayStartInput.addEventListener('input', updateVisibility);
+displayEndInput.addEventListener('input', updateVisibility);
 
 startInput.addEventListener('input', () => {
   if (selectedElement) {
@@ -1075,12 +1077,13 @@ lineTypeSelect.addEventListener('change', () => {
 });
 
 function updateVisibility() {
-  const t = Number(timeSlider.value);
+  const start = Number(displayStartInput.value);
+  const end = Number(displayEndInput.value);
   Array.from(canvasContent.children).forEach(el => {
     if (el.classList.contains('resize-handle') || el.classList.contains('vertex-handle')) return;
     const s = Number(el.dataset.start);
     const e = Number(el.dataset.end);
-    el.style.display = t >= s && t <= e ? '' : 'none';
+    el.style.display = e >= start && s <= end ? '' : 'none';
   });
   if (resizeHandle) resizeHandle.style.display = '';
   vertexHandles.forEach(h => (h.style.display = ''));


### PR DESCRIPTION
## Summary
- Replace single-index slider with display start/end inputs
- Show objects if their index range overlaps the display range

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7540c69c83318d42aa8ee511371f