### PR TITLE
Organize toolbar into global and object attribute groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,69 +7,73 @@
 </head>
 <body>
   <div id="toolbar">
-    <label>Tool:
-      <select id="tool">
-        <option value="select">選択</option>
-        <option value="rect" selected>四角</option>
-        <option value="circle">丸</option>
-        <option value="line">ライン</option>
-        <option value="polygon">ポリゴン</option>
-        <option value="polyline">ポリライン</option>
-        <option value="path">パス</option>
-        <option value="text">文字</option>
-        <option value="bubble">吹き出し</option>
-        <option value="arrow">矢印</option>
-      </select>
-    </label>
-    <label>開始: <input type="number" id="startTime" value="0" max="99999" /></label>
-    <label>終了: <input type="number" id="endTime" value="10" max="99999" /></label>
-    <label>テキスト: <input type="text" id="textInput" /></label>
-    <label>線色: <input type="color" id="strokeColor" value="#000000" /></label>
-    <label>線幅: <input type="number" id="strokeWidth" value="1" min="1" /></label>
-    <label>線種:
-      <select id="lineType">
-        <option value="">実線</option>
-        <option value="5,5">破線</option>
-        <option value="1,5">点線</option>
-      </select>
-    </label>
-    <label>塗り色: <input type="color" id="fillColor" value="#ffffff" /></label>
-    <label>背景色: <input type="color" id="backgroundColor" value="#ffffff" /></label>
-    <label>操作レイヤ:
-      <select id="activeLayer">
-        <option value="0" selected>0</option>
-        <option value="1">1</option>
-        <option value="2">2</option>
-        <option value="3">3</option>
-      </select>
-    </label>
-    <label>表示レイヤ:
-      <span id="displayLayers">
-        <label><input type="checkbox" class="display-layer" value="0" checked />0</label>
-        <label><input type="checkbox" class="display-layer" value="1" checked />1</label>
-        <label><input type="checkbox" class="display-layer" value="2" checked />2</label>
-        <label><input type="checkbox" class="display-layer" value="3" checked />3</label>
-      </span>
-    </label>
-    <label>レイヤ移動:
-      <select id="moveLayer">
-        <option value="0">0</option>
-        <option value="1">1</option>
-        <option value="2">2</option>
-        <option value="3">3</option>
-      </select>
-      <button id="moveLayerBtn">移動</button>
-    </label>
-    <button id="bringForwardBtn">前面へ</button>
-    <button id="sendBackwardBtn">背面へ</button>
-    <button id="groupBtn">グループ化</button>
-    <button id="ungroupBtn">グループ解除</button>
-    <button id="deleteBtn">削除</button>
-    <button id="saveBtn" class="custom-button">Save</button>
-    <label for="loadInput" class="custom-button">Load</label>
-    <input type="file" id="loadInput" style="display:none;">
-    <label>表示開始: <input type="number" id="displayStart" value="0" max="99999" /></label>
-    <label>表示終了: <input type="number" id="displayEnd" value="10" max="99999" /></label>
+    <div class="toolbar-group">
+      <label>Tool:
+        <select id="tool">
+          <option value="select">選択</option>
+          <option value="rect" selected>四角</option>
+          <option value="circle">丸</option>
+          <option value="line">ライン</option>
+          <option value="polygon">ポリゴン</option>
+          <option value="polyline">ポリライン</option>
+          <option value="path">パス</option>
+          <option value="text">文字</option>
+          <option value="bubble">吹き出し</option>
+          <option value="arrow">矢印</option>
+        </select>
+      </label>
+      <label>背景色: <input type="color" id="backgroundColor" value="#ffffff" /></label>
+      <label>操作レイヤ:
+        <select id="activeLayer">
+          <option value="0" selected>0</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+        </select>
+      </label>
+      <label>表示レイヤ:
+        <span id="displayLayers">
+          <label><input type="checkbox" class="display-layer" value="0" checked />0</label>
+          <label><input type="checkbox" class="display-layer" value="1" checked />1</label>
+          <label><input type="checkbox" class="display-layer" value="2" checked />2</label>
+          <label><input type="checkbox" class="display-layer" value="3" checked />3</label>
+        </span>
+      </label>
+      <label>レイヤ移動:
+        <select id="moveLayer">
+          <option value="0">0</option>
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="3">3</option>
+        </select>
+        <button id="moveLayerBtn">移動</button>
+      </label>
+      <button id="bringForwardBtn">前面へ</button>
+      <button id="sendBackwardBtn">背面へ</button>
+      <button id="groupBtn">グループ化</button>
+      <button id="ungroupBtn">グループ解除</button>
+      <button id="deleteBtn">削除</button>
+      <button id="saveBtn" class="custom-button">Save</button>
+      <label for="loadInput" class="custom-button">Load</label>
+      <input type="file" id="loadInput" style="display:none;">
+      <label>表示開始: <input type="number" id="displayStart" value="0" max="99999" /></label>
+      <label>表示終了: <input type="number" id="displayEnd" value="10" max="99999" /></label>
+    </div>
+    <div class="toolbar-group">
+      <label>開始: <input type="number" id="startTime" value="0" max="99999" /></label>
+      <label>終了: <input type="number" id="endTime" value="10" max="99999" /></label>
+      <label>テキスト: <input type="text" id="textInput" /></label>
+      <label>線色: <input type="color" id="strokeColor" value="#000000" /></label>
+      <label>線幅: <input type="number" id="strokeWidth" value="1" min="1" /></label>
+      <label>線種:
+        <select id="lineType">
+          <option value="">実線</option>
+          <option value="5,5">破線</option>
+          <option value="1,5">点線</option>
+        </select>
+      </label>
+      <label>塗り色: <input type="color" id="fillColor" value="#ffffff" /></label>
+    </div>
   </div>
   <svg id="canvas">
     <g id="canvasContent"></g>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,14 @@
 body { font-family: sans-serif; margin: 0; }
 #toolbar { margin-bottom: 8px; }
+.toolbar-group {
+  display: inline-block;
+  margin-right: 16px;
+  padding-right: 16px;
+  border-right: 1px solid #ccc;
+}
+.toolbar-group:last-child {
+  border-right: none;
+}
 #canvas { border: 1px solid #ccc; }
 .selected { outline: 1px dashed red; }
 .resize-handle { fill: #ffffff; stroke: #000000; cursor: se-resize; }


### PR DESCRIPTION
## Summary
- Split toolbar controls into global actions and object-specific attribute editors for easier navigation.
- Added basic styling to visually separate toolbar groups.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd38ba502c8331880e590f38a2a3b6