### PR TITLE
feat: support multi-object area selection

### DIFF
--- a/style.css
+++ b/style.css
@@ -13,6 +13,12 @@ body { font-family: sans-serif; margin: 0; }
 .selected { outline: 1px dashed red; }
 .resize-handle { fill: #ffffff; stroke: #000000; cursor: se-resize; }
 .vertex-handle { fill: #ffffff; stroke: #000000; cursor: move; }
+.selection-rect {
+  fill: rgba(0, 0, 255, 0.1);
+  stroke: #0000ff;
+  stroke-dasharray: 4;
+  pointer-events: none;
+}
 #startTime,
 #endTime,
 #strokeWidth,


### PR DESCRIPTION
## Summary
- allow selecting multiple elements by dragging a marquee rectangle
- style selection rectangle overlay

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3cb3e6d48331ab64263f692ba449