### PR TITLE
Enable right-click drag panning

### DIFF
--- a/script.js
+++ b/script.js
@@ -151,7 +151,15 @@ svg.addEventListener('wheel', e => {
   }
 });
 
+svg.addEventListener('contextmenu', e => e.preventDefault());
+
 svg.addEventListener('mousedown', e => {
+  if (e.button === 2) {
+    isPanning = true;
+    startDragX = e.clientX;
+    startDragY = e.clientY;
+    return;
+  }
   const pt = getMousePos(e);
   if (
     selectedElements.length === 1 &&
@@ -191,12 +199,8 @@ svg.addEventListener('mousedown', e => {
       selectionRect.setAttribute('width', 0);
       selectionRect.setAttribute('height', 0);
       canvasContent.appendChild(selectionRect);
-    } else if (e.target === svg) {
-      isPanning = true;
-      startDragX = e.clientX;
-      startDragY = e.clientY;
     } else {
-      deselect();
+      if (e.target !== svg) deselect();
     }
     return; // skip drawing when selecting
   }


### PR DESCRIPTION
## Summary
- Allow panning by dragging with the right mouse button regardless of selected tool
- Disable the browser context menu so right-click dragging always pans

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd46b180308331b46b2d21df8a27bf