### PR TITLE
Disable text selection while drawing

### DIFF
--- a/script.js
+++ b/script.js
@@ -154,6 +154,7 @@ svg.addEventListener('wheel', e => {
 svg.addEventListener('contextmenu', e => e.preventDefault());
 
 svg.addEventListener('mousedown', e => {
+  e.preventDefault();
   if (e.button === 2) {
     isPanning = true;
     startDragX = e.clientX;

--- a/style.css
+++ b/style.css
@@ -9,7 +9,10 @@ body { font-family: sans-serif; margin: 0; }
 .toolbar-group:last-child {
   border-right: none;
 }
-#canvas { border: 1px solid #ccc; }
+#canvas {
+  border: 1px solid #ccc;
+  user-select: none;
+}
 .selected { outline: 1px dashed red; }
 .resize-handle { fill: #ffffff; stroke: #000000; cursor: se-resize; }
 .vertex-handle { fill: #ffffff; stroke: #000000; cursor: move; }


### PR DESCRIPTION
## Summary
- Prevent the browser from highlighting text when dragging on the canvas
- Disable user selection within the SVG canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd48956da4833199c31a1ab51ee85c