### PR TITLE
Add copy and paste functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disa
 - Preview visibility with a timeline slider.
 - Save drawings to a JSON file and load them back later.
 - Move elements by selecting them or by holding Ctrl and clicking to temporarily enter selection mode.
+- Copy and paste selected elements using toolbar buttons or Ctrl+C/Ctrl+V shortcuts.
 
 ## Getting Started
 1. Clone or download this repository.
@@ -30,6 +31,7 @@ No build step or server is required; everything runs locally.
 4. Drag the timeline slider to preview element visibility.
 5. Use **Save** to download the current drawing as `drawing.json`.
 6. Use the file input next to **Save** to load a previously saved drawing.
+7. Duplicate elements with the **コピー** and **貼り付け** buttons or with keyboard shortcuts.
 
 ## License
 This project is available under the MIT License.

--- a/index.html
+++ b/index.html
@@ -74,6 +74,8 @@
       <button id="sendBackwardBtn">背面へ</button>
       <button id="groupBtn">group化</button>
       <button id="ungroupBtn">group解除</button>
+      <button id="copyBtn">コピー</button>
+      <button id="pasteBtn">貼り付け</button>
       <button id="deleteBtn">削除</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enable copying and pasting of selected SVG elements with toolbar buttons and Ctrl+C/Ctrl+V
- document copy/paste shortcuts and usage in the README

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd564c365c83319264bb9a83c0f1e8