### PR TITLE
Add import feature to append drawings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple in-browser SVG drawing tool with a timeline. Shapes can appear and disa
 - Zoom the canvas with the mouse wheel, or resize a selected element by holding Shift while scrolling.
 - Preview visibility with a timeline slider.
 - Save drawings to a JSON file and load them back later.
+- Import additional drawings from JSON without clearing the current canvas.
 - Move elements by selecting them or by holding Ctrl and clicking to temporarily enter selection mode.
 - Copy and paste selected elements using toolbar buttons or Ctrl+C/Ctrl+V shortcuts.
 
@@ -31,7 +32,8 @@ No build step or server is required; everything runs locally.
 4. Drag the timeline slider to preview element visibility.
 5. Use **Save** to download the current drawing as `drawing.json`.
 6. Use the file input next to **Save** to load a previously saved drawing.
-7. Duplicate elements with the **コピー** and **貼り付け** buttons or with keyboard shortcuts.
+7. Use **Import** to merge another saved drawing into the current canvas.
+8. Duplicate elements with the **コピー** and **貼り付け** buttons or with keyboard shortcuts.
 
 ## License
 This project is available under the MIT License.

--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
       <button id="saveBtn" class="custom-button">Save</button>
       <label for="loadInput" class="custom-button">Load</label>
       <input type="file" id="loadInput" style="display:none;">
+      <label for="importInput" class="custom-button">Import</label>
+      <input type="file" id="importInput" style="display:none;">
       <label>表示開始: <input type="number" id="displayStart" value="0" max="99999" /></label>
       <label>表示終了: <input type="number" id="displayEnd" value="10" max="99999" /></label>
     </div>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,7 @@ const endInput = document.getElementById('endTime');
 const textInput = document.getElementById('textInput');
 const saveBtn = document.getElementById('saveBtn');
 const loadInput = document.getElementById('loadInput');
+const importInput = document.getElementById('importInput');
 const displayStartInput = document.getElementById('displayStart');
 const displayEndInput = document.getElementById('displayEnd');
 const deleteBtn = document.getElementById('deleteBtn');
@@ -1224,6 +1225,33 @@ loadInput.addEventListener('change', () => {
     });
     svg.style.backgroundColor = background;
     backgroundInput.value = background;
+    updateVisibility();
+  };
+  reader.readAsText(file);
+});
+
+importInput.addEventListener('change', () => {
+  const file = importInput.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = e => {
+    const data = JSON.parse(e.target.result);
+    let elements;
+    if (Array.isArray(data)) {
+      elements = data;
+    } else {
+      elements = data.elements || [];
+      if (data.background) {
+        svg.style.backgroundColor = data.background;
+        backgroundInput.value = data.background;
+      }
+    }
+    deselect();
+    elements.forEach(obj => {
+      const el = deserializeElement(obj);
+      const layerIdx = Number(obj.layer) || 0;
+      layers[layerIdx].appendChild(el);
+    });
     updateVisibility();
   };
   reader.readAsText(file);


### PR DESCRIPTION
## Summary
- allow importing drawings without clearing existing canvas by adding a new Import file input
- append deserialized elements and optionally update background
- document the Import feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd83dda7bc83318889ec0ec963dc69