### PR TITLE
Expand layer count from 4 to 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,12 @@
           <option value="1">1</option>
           <option value="2">2</option>
           <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
         </select>
       </label>
       <label>表示レイヤ:
@@ -23,6 +29,12 @@
           <label><input type="checkbox" class="display-layer" value="1" checked />1</label>
           <label><input type="checkbox" class="display-layer" value="2" checked />2</label>
           <label><input type="checkbox" class="display-layer" value="3" checked />3</label>
+          <label><input type="checkbox" class="display-layer" value="4" checked />4</label>
+          <label><input type="checkbox" class="display-layer" value="5" checked />5</label>
+          <label><input type="checkbox" class="display-layer" value="6" checked />6</label>
+          <label><input type="checkbox" class="display-layer" value="7" checked />7</label>
+          <label><input type="checkbox" class="display-layer" value="8" checked />8</label>
+          <label><input type="checkbox" class="display-layer" value="9" checked />9</label>
         </span>
       </label>
 
@@ -78,6 +90,12 @@
           <option value="1">1</option>
           <option value="2">2</option>
           <option value="3">3</option>
+          <option value="4">4</option>
+          <option value="5">5</option>
+          <option value="6">6</option>
+          <option value="7">7</option>
+          <option value="8">8</option>
+          <option value="9">9</option>
         </select>
         <button id="moveLayerBtn">移動</button>
       </label>

--- a/script.js
+++ b/script.js
@@ -97,6 +97,7 @@ function updateTransform() {
 }
 updateTransform();
 
+const LAYER_COUNT = 10;
 const layers = [];
 const MAX_HISTORY = 10;
 const undoStack = [];
@@ -165,7 +166,7 @@ function redo() {
 function initLayers() {
   canvasContent.innerHTML = '';
   layers.length = 0;
-  for (let i = 0; i < 4; i++) {
+  for (let i = 0; i < LAYER_COUNT; i++) {
     const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
     g.dataset.layer = i;
     canvasContent.appendChild(g);


### PR DESCRIPTION
### Motivation
- The editor previously provided only four layers (`0-3`) in the UI and in layer initialization, but the layer range needs to be extended to `0-9` to support more content.

### Description
- Introduced a `LAYER_COUNT = 10` constant and updated `initLayers()` to create `LAYER_COUNT` SVG layer groups instead of a hardcoded `4` loop. 
- Expanded the `#activeLayer` and `#moveLayer` `<select>` options to include values `0` through `9` in `index.html`.
- Added display checkboxes for layers `4` through `9` inside the `#displayLayers` span in `index.html` so visibility toggles cover all layers. 
- No other editor logic was changed; layer-related code now uses the updated layer count at initialization and for element placement.

### Testing
- Verified the code changes via repository diffs and source searches to ensure the hardcoded `4` loop was replaced and new options/checkboxes for `0-9` were added (succeeded). 
- Confirmed `initLayers()` now iterates up to `LAYER_COUNT` and that created `<g>` elements have `data-layer` values `0`–`9` (succeeded). 
- Started a local HTTP server to serve the UI for visual validation (server start succeeded). 
- Attempted automated UI screenshot via Playwright/Chromium, but the headless browser failed to launch in this environment due to a runtime crash (`SIGSEGV`) so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb44bb2f0833182a001408913d3f3)