### PR TITLE
Preserve group rotate transform during drag (include transform in group start)

### DIFF
--- a/script.js
+++ b/script.js
@@ -1135,10 +1135,13 @@ function getElementStart(el) {
     case 'text':
       return { x: parseFloat(el.getAttribute('x')), y: parseFloat(el.getAttribute('y')), transform: el.getAttribute('transform') || '' };
     case 'g':
-      return Array.from(el.children).map(child => ({
-        el: child,
-        start: getElementStart(child)
-      }));
+      return {
+        children: Array.from(el.children).map(child => ({
+          el: child,
+          start: getElementStart(child)
+        })),
+        transform: el.getAttribute('transform') || ''
+      };
     default:
       return {};
   }
@@ -1268,9 +1271,11 @@ function moveElement(el, start, dx, dy) {
       el.setAttribute('x', start.x + dx);
       el.setAttribute('y', start.y + dy);
       break;
-    case 'g':
-      start.forEach(obj => moveElement(obj.el, obj.start, dx, dy));
+    case 'g': {
+      const groupChildren = Array.isArray(start) ? start : start.children || [];
+      groupChildren.forEach(obj => moveElement(obj.el, obj.start, dx, dy));
       break;
+    }
   }
 
   if (hadStartTransform) {


### PR DESCRIPTION
### Motivation
- Group elements lost their `transform`/rotation center during drag because `getElementStart` returned only a child-start array for `g`, so we need to pass the group's `transform` alongside its children to keep rotation center consistent.
- The goal is to reuse existing rotation parsing (`parseRotateTransform`) and apply `cx/cy` offset during dragging so group drag direction matches mouse under various rotation angles.

### Description
- Updated `getElementStart(el)` for `case 'g'` to return an object `{ children, transform }` where `children` is an array of `{ el, start }` and `transform` is the group's `transform` string. 
- Updated `moveElement(el, start, dx, dy)` for `case 'g'` to recurse over `start.children` when present and kept a compatibility branch to accept legacy array-form `start` for existing save data. 
- Left the shared `parseRotateTransform` usage in place so group rotation centers are adjusted by `dx/dy` via the existing transform handling path.

### Testing
- Ran `node --check script.js` to validate syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a024c7c86483318846c5e2de4f7c89)